### PR TITLE
Fixes scrollbar width detection in IE7

### DIFF
--- a/css3-mediaqueries.js
+++ b/css3-mediaqueries.js
@@ -946,6 +946,8 @@ domReady(function enableCssMediaQueries() {
 		// determine scrollbar width in IE, see resizeHandler
 		if (ua.ie) {
 			var el = document.createElement('div');
+			el.style.width = '100px';
+			el.style.height = '100px';
 			el.style.position = 'absolute';
 			el.style.top = '-9999em';
 			el.style.overflow = 'scroll';


### PR DESCRIPTION
In IE7 and possible older, the scroll bar width was not being detected correctly. Since the width/height of the test div were not set, scrollbarWidth was consistently set to 0. This caused resizeHandler to get called repeatedly even when the browser size wasn't changing. This pull request fixes that issue.
