### PR TITLE
Semi-gracefully handle IE errors while trying to re-inject mediaquery css.

### DIFF
--- a/css3-mediaqueries.js
+++ b/css3-mediaqueries.js
@@ -545,7 +545,9 @@ var cssHelper = function () {
 			el.setAttribute('type', 'text/css');
 			document.getElementsByTagName('head')[0].appendChild(el);
 			if (el.styleSheet) { // IE
-				el.styleSheet.cssText = s;
+				try { 
+					el.styleSheet.cssText = s;
+				} catch (e) {} // IE will generate errors if it doesn't like the CSS; unless we try/catch here all processing will stop.
 			}
 			else {
 				el.appendChild(document.createTextNode(s));


### PR DESCRIPTION
IE9 was erroring out processing some @media queries on our site. Why, I don't know. However without the try/catch the css3-mediaqueries.js script will stop processing further instructions, leaving the page in an often broken state. At least this allows it to proceed further.

I don't know enough about how this script works to know why it was failing, however something about some of the media queries in our CSS was causing css3-mediaqueries.js to try to add cssText of code that IE didn't like. Whether this is a bug in detecting which mediaqueries need to be "re-added" or what I have no idea.
