### PR TITLE
Fix for domReady in iframes in IE <8

### DIFF
--- a/css3-mediaqueries.js
+++ b/css3-mediaqueries.js
@@ -65,6 +65,11 @@ var domReady = function () {
 			try {
 				// throws errors until after ondocumentready
 				document.documentElement.doScroll('left');
+				
+				// If we are in an iframe, the above does not work properly.
+        // Trying to access the length attribute of document.body, however,
+        // does throw an error until ondocumentready, fixing this issue.
+        document.body.length;
 			}
 			catch (e) {
 				setTimeout(arguments.callee, 50);


### PR DESCRIPTION
The domReady function did not work properly in IE7&8 when the page using css3-mediaqueries was loaded in an iframe.
Fixed this by trying to access the length attribute of the body, which does throw an error until ondocumentready.
