### PR TITLE
css3-mediaqueries.js not work for CSS files located on a CDN.

### DIFF
--- a/css3-mediaqueries.js
+++ b/css3-mediaqueries.js
@@ -165,6 +165,9 @@ var cssHelper = function () {
 		}
 		var r = new XMLHttpRequest();
 		try {
+			// APCIHACK - Make this library work for CDN resources.
+			url = url.replace(/^https\:\/\/[^.]+\.cloudfront\.net/g, (document.location.protocol + '//' + document.location.hostname));
+			url = url.replace('https://files.', 'https://www.');
 			r.open('get', url, true);
 			r.setRequestHeader('X_REQUESTED_WITH', 'XMLHttpRequest');
 		}


### PR DESCRIPTION
I do not at all expect for you to pull this into the project, but am just adding this Pull Request to get it out there if anyone else has the same issue we had with this library.

This library works great as long as your CSS files are located on the same domain as your site.  However, if you are using a CDN, the XHR open fails to load the resources and this module does not work as designed.  I realize that there maybe more elegant ways to fix this, but here is what we had to do to get this to work for us, which will also only work for Origin-Pull type CDN's.  As you can see it isn't generic at all, but should give someone else the idea of what needs to happen.
