### PR TITLE
fix for @-moz-document url-prefix issue

### DIFF
--- a/css3-mediaqueries.js
+++ b/css3-mediaqueries.js
@@ -122,7 +122,7 @@ var cssHelper = function () {
 		DECLARATIONS: /[a-zA-Z\-]+[^;]*:[^;]+;/g,
 		RELATIVE_URLS: /url\(['"]?([^\/\)'"][^:\)'"]+)['"]?\)/g,
 		// strip whitespace and comments, @import is evil
-		REDUNDANT_COMPONENTS: /(?:\/\*([^*\\\\]|\*(?!\/))+\*\/|@import[^;]+;|@-moz-document url-prefix\(\)\s*{(([^{}])+{([^{}])+}([^{}])+)+})/g,
+		REDUNDANT_COMPONENTS: /(?:\/\*([^*\\\\]|\*(?!\/))+\*\/|@import[^;]+;|@-moz-document\s*url-prefix\(\)\s*{(([^{}])+{([^{}])+}([^{}])+)+})/g,
 		REDUNDANT_WHITESPACE: /\s*(,|:|;|\{|\})\s*/g,
 		MORE_WHITESPACE: /\s{2,}/g,
 		FINAL_SEMICOLONS: /;\}/g,


### PR DESCRIPTION
Fix for Issue https://github.com/livingston/css3-mediaqueries-js/issues/8

Usage of @-moz-document url-prefix within @media queries causes IE8 to crash when processing

Updated the regex for sanitizing @-moz-document url-prefix blocks

``` javascript
REDUNDANT_COMPONENTS: /(?:\/\*([^*\\\\]|\*(?!\/))+\*\/|@import[^;]+;|@-moz-document\s*url-prefix\(\)\s*{(([^{}])+{([^{}])+}([^{}])+)+})/g,
```

This regex can probably be cleaned up a little, but this should match and filter out any usage similar to the following:

``` css
@media only screen and (min-width: 1025px) {
    #hero{
        margin-top: 180px;
        margin-bottom: 110px;
    }

    @-moz-document url-prefix() {
        #hero .content-inner{
            width: 800px;
        }
        #other{
            width: 600px;
        }
    }

    #hero .paragraph{
        width:375px;
    }
}
```

The regex basically will match a @-moz-document url-prefix() selector with multiple nested CSS rules
